### PR TITLE
[#7]feat: 로그인 기능 구현 token 발급, token 정보 확인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,36 +1,45 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.2'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.2'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'soma.haeya'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // jjwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.squareup.okhttp3:mockwebserver'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/soma/haeya/edupi_user/login/auth/TokenProvider.java
+++ b/src/main/java/soma/haeya/edupi_user/login/auth/TokenProvider.java
@@ -1,0 +1,79 @@
+package soma.haeya.edupi_user.login.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import soma.haeya.edupi_user.login.domain.Member;
+import soma.haeya.edupi_user.login.domain.Role;
+import soma.haeya.edupi_user.login.dto.TokenInfo;
+
+@Component
+public class TokenProvider {
+
+    private final SecretKey key;
+    private final long expiration;
+
+    public TokenProvider(@Value("${jwt.secret}") String secret,
+        @Value("${jwt.expiration}") long expiration) {
+        this.key = generateKey(secret);
+        this.expiration = expiration;
+    }
+
+    public String generateToken(Member member) {
+        long now = (new Date()).getTime();
+        Date tokenExpiration = new Date(now + expiration);
+
+        return Jwts.builder()
+            .claim("email", member.getEmail())
+            .claim("name", member.getName())
+            .claim("role", member.getRole())
+            .signWith(key, SIG.HS512)
+            .expiration(tokenExpiration)
+            .compact();
+    }
+
+    public TokenInfo findUserInfoBy(String token) {
+        Claims claims = getClaims(token);
+
+        isTokenExpired(claims); // 토큰이 유효한지 검사
+
+        return TokenInfo.builder()
+            .email(claims.get("email", String.class))
+            .name(claims.get("name", String.class))
+            .role(Role.valueOf(claims.get("role", String.class)))
+            .build();
+    }
+
+    private SecretKey generateKey(String secret) {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private Claims getClaims(String token) {
+        if (token == null || token.isEmpty()) {
+            throw new IllegalArgumentException("토큰이 없습니다.");
+        }
+
+        try {
+            return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    private void isTokenExpired(Claims claims) {
+        if (claims.getExpiration().before(new Date())) {
+            throw new JwtException("토큰이 만료되었습니다.");
+        }
+    }
+
+}

--- a/src/main/java/soma/haeya/edupi_user/login/client/MemberApiClient.java
+++ b/src/main/java/soma/haeya/edupi_user/login/client/MemberApiClient.java
@@ -1,0 +1,17 @@
+package soma.haeya.edupi_user.login.client;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+import soma.haeya.edupi_user.login.domain.Member;
+import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
+
+@Component
+@HttpExchange("/api/v1/member")
+public interface MemberApiClient {
+
+    @PostExchange("/login")
+    Member findMemberByEmailAndPassword(@RequestBody MemberLoginRequest memberLoginRequest);
+
+}

--- a/src/main/java/soma/haeya/edupi_user/login/client/MemberApiClient.java
+++ b/src/main/java/soma/haeya/edupi_user/login/client/MemberApiClient.java
@@ -12,6 +12,6 @@ import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
 public interface MemberApiClient {
 
     @PostExchange("/login")
-    Member findMemberByEmailAndPassword(@RequestBody MemberLoginRequest memberLoginRequest);
+    Member retrieveMemberByEmailAndPassword(@RequestBody MemberLoginRequest memberLoginRequest);
 
 }

--- a/src/main/java/soma/haeya/edupi_user/login/client/config/MemberApiRestClientConfig.java
+++ b/src/main/java/soma/haeya/edupi_user/login/client/config/MemberApiRestClientConfig.java
@@ -1,0 +1,24 @@
+package soma.haeya.edupi_user.login.client.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+import soma.haeya.edupi_user.login.client.MemberApiClient;
+
+@Configuration
+public class MemberApiRestClientConfig {
+
+    @Bean
+    public MemberApiClient memberApiClient(
+        @Value("${server-url.db-server}") String dbUrl) {
+        RestClient restClient = RestClient.builder().baseUrl(dbUrl).build();
+        RestClientAdapter adapter = RestClientAdapter.create(restClient);
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
+
+        return factory.createClient(MemberApiClient.class);
+    }
+
+}

--- a/src/main/java/soma/haeya/edupi_user/login/controller/MemberController.java
+++ b/src/main/java/soma/haeya/edupi_user/login/controller/MemberController.java
@@ -25,7 +25,7 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseEntity<Void> login(@Valid @RequestBody MemberLoginRequest memberLoginRequest,
         HttpServletResponse response) {
-        String token = memberService.memberLogin(memberLoginRequest);
+        String token = memberService.login(memberLoginRequest);
 
         Cookie cookie = new Cookie("token", token);
         cookie.setPath("/");
@@ -38,7 +38,7 @@ public class MemberController {
 
     @GetMapping("/login/info")
     public ResponseEntity<TokenInfo> loginInfo(@CookieValue("token") String token) {
-        TokenInfo tokenInfo = memberService.findUserInfo(token);
+        TokenInfo tokenInfo = memberService.findMemberInfo(token);
 
         return ResponseEntity.ok(tokenInfo);
     }

--- a/src/main/java/soma/haeya/edupi_user/login/controller/MemberController.java
+++ b/src/main/java/soma/haeya/edupi_user/login/controller/MemberController.java
@@ -1,0 +1,47 @@
+package soma.haeya.edupi_user.login.controller;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
+import soma.haeya.edupi_user.login.dto.TokenInfo;
+import soma.haeya.edupi_user.login.service.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@Valid @RequestBody MemberLoginRequest memberLoginRequest,
+        HttpServletResponse response) {
+        String token = memberService.memberLogin(memberLoginRequest);
+
+        Cookie cookie = new Cookie("token", token);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/login/info")
+    public ResponseEntity<TokenInfo> loginInfo(@CookieValue("token") String token) {
+        TokenInfo tokenInfo = memberService.findUserInfo(token);
+
+        return ResponseEntity.ok(tokenInfo);
+    }
+
+
+}

--- a/src/main/java/soma/haeya/edupi_user/login/domain/Member.java
+++ b/src/main/java/soma/haeya/edupi_user/login/domain/Member.java
@@ -1,27 +1,31 @@
 package soma.haeya.edupi_user.login.domain;
 
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class Member {
 
-    private final Long id;
-    private final String password;
-    private final String email;
-    private final String name;
-    private final Role role;
+    private Long id;
+    private String password;
+    private String email;
+    private String name;
+    private Role role;
 
-    @JsonCreator
-    public Member(Long id, String email, String password, String name, String role
-    ) {
+    public Member(Long id, String email, String password, String name, Role role) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.name = name;
-        this.role = Role.valueOf(role);
+        this.role = role;
     }
+
+    public Member(String email, String name, Role role) {
+        this.email = email;
+        this.name = name;
+        this.role = role;
+    }
+
 }

--- a/src/main/java/soma/haeya/edupi_user/login/domain/Member.java
+++ b/src/main/java/soma/haeya/edupi_user/login/domain/Member.java
@@ -1,31 +1,27 @@
 package soma.haeya.edupi_user.login.domain;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class Member {
 
-    private Long id;
-    private String password;
-    private String email;
-    private String name;
-    private Role role;
+    private final Long id;
+    private final String password;
+    private final String email;
+    private final String name;
+    private final Role role;
 
-    public Member(Long id, String email, String password, String name, Role role) {
+    @JsonCreator
+    public Member(Long id, String email, String password, String name, String role
+    ) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.name = name;
-        this.role = role;
+        this.role = Role.valueOf(role);
     }
-
-    public Member(String email, String name, Role role) {
-        this.email = email;
-        this.name = name;
-        this.role = role;
-    }
-
 }

--- a/src/main/java/soma/haeya/edupi_user/login/domain/Member.java
+++ b/src/main/java/soma/haeya/edupi_user/login/domain/Member.java
@@ -1,0 +1,31 @@
+package soma.haeya.edupi_user.login.domain;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Member {
+
+    private Long id;
+    private String password;
+    private String email;
+    private String name;
+    private Role role;
+
+    public Member(Long id, String email, String password, String name, Role role) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.role = role;
+    }
+
+    public Member(String email, String name, Role role) {
+        this.email = email;
+        this.name = name;
+        this.role = role;
+    }
+
+}

--- a/src/main/java/soma/haeya/edupi_user/login/domain/Role.java
+++ b/src/main/java/soma/haeya/edupi_user/login/domain/Role.java
@@ -1,0 +1,5 @@
+package soma.haeya.edupi_user.login.domain;
+
+public enum Role {
+    ROLE_USER
+}

--- a/src/main/java/soma/haeya/edupi_user/login/dto/MemberLoginRequest.java
+++ b/src/main/java/soma/haeya/edupi_user/login/dto/MemberLoginRequest.java
@@ -1,0 +1,20 @@
+package soma.haeya.edupi_user.login.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberLoginRequest {
+
+    @NotNull
+    @NotBlank
+    private String email;
+
+    @NotNull
+    @NotBlank
+    private String password;
+
+}

--- a/src/main/java/soma/haeya/edupi_user/login/dto/TokenInfo.java
+++ b/src/main/java/soma/haeya/edupi_user/login/dto/TokenInfo.java
@@ -1,0 +1,16 @@
+package soma.haeya.edupi_user.login.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import soma.haeya.edupi_user.login.domain.Role;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class TokenInfo {
+
+    private String email;
+    private String name;
+    private Role role;
+}

--- a/src/main/java/soma/haeya/edupi_user/login/service/MemberService.java
+++ b/src/main/java/soma/haeya/edupi_user/login/service/MemberService.java
@@ -17,13 +17,13 @@ public class MemberService {
     private final MemberApiClient memberApiClient;
     private final TokenProvider tokenProvider;
 
-    public String memberLogin(MemberLoginRequest memberLoginRequest) {
+    public String login(MemberLoginRequest memberLoginRequest) {
         Member findMember = memberApiClient.findMemberByEmailAndPassword(memberLoginRequest);
 
         return tokenProvider.generateToken(findMember);
     }
 
-    public TokenInfo findUserInfo(String token) {
+    public TokenInfo findMemberInfo(String token) {
         return tokenProvider.findUserInfoBy(token);
     }
 

--- a/src/main/java/soma/haeya/edupi_user/login/service/MemberService.java
+++ b/src/main/java/soma/haeya/edupi_user/login/service/MemberService.java
@@ -18,7 +18,7 @@ public class MemberService {
     private final TokenProvider tokenProvider;
 
     public String login(MemberLoginRequest memberLoginRequest) {
-        Member findMember = memberApiClient.findMemberByEmailAndPassword(memberLoginRequest);
+        Member findMember = memberApiClient.retrieveMemberByEmailAndPassword(memberLoginRequest);
 
         return tokenProvider.generateToken(findMember);
     }

--- a/src/main/java/soma/haeya/edupi_user/login/service/MemberService.java
+++ b/src/main/java/soma/haeya/edupi_user/login/service/MemberService.java
@@ -1,0 +1,31 @@
+package soma.haeya.edupi_user.login.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import soma.haeya.edupi_user.login.auth.TokenProvider;
+import soma.haeya.edupi_user.login.client.MemberApiClient;
+import soma.haeya.edupi_user.login.domain.Member;
+import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
+import soma.haeya.edupi_user.login.dto.TokenInfo;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberApiClient memberApiClient;
+    private final TokenProvider tokenProvider;
+
+    public String memberLogin(MemberLoginRequest memberLoginRequest) {
+        Member findMember = memberApiClient.findMemberByEmailAndPassword(memberLoginRequest);
+
+        return tokenProvider.generateToken(findMember);
+    }
+
+    public TokenInfo findUserInfo(String token) {
+        return tokenProvider.findUserInfoBy(token);
+    }
+
+
+}

--- a/src/test/java/soma/haeya/edupi_user/login/auth/TokenProviderTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/auth/TokenProviderTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import soma.haeya.edupi_user.login.domain.Member;
-import soma.haeya.edupi_user.login.domain.Role;
 import soma.haeya.edupi_user.login.dto.TokenInfo;
 
 @SpringBootTest
@@ -20,7 +19,7 @@ public class TokenProviderTest {
 
     @BeforeEach
     void init() {
-        member = new Member("asdf@naver.com", "홍길동", Role.ROLE_USER);
+        member = new Member(1L, "asdf@naver.com", "asdf1234", "홍길동", "ROLE_USER");
     }
 
     @Test

--- a/src/test/java/soma/haeya/edupi_user/login/auth/TokenProviderTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/auth/TokenProviderTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import soma.haeya.edupi_user.login.domain.Member;
+import soma.haeya.edupi_user.login.domain.Role;
 import soma.haeya.edupi_user.login.dto.TokenInfo;
 
 @SpringBootTest
@@ -19,7 +20,7 @@ public class TokenProviderTest {
 
     @BeforeEach
     void init() {
-        member = new Member(1L, "asdf@naver.com", "asdf1234", "홍길동", "ROLE_USER");
+        member = new Member("asdf@naver.com", "홍길동", Role.ROLE_USER);
     }
 
     @Test

--- a/src/test/java/soma/haeya/edupi_user/login/auth/TokenProviderTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/auth/TokenProviderTest.java
@@ -1,0 +1,45 @@
+package soma.haeya.edupi_user.login.auth;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import soma.haeya.edupi_user.login.domain.Member;
+import soma.haeya.edupi_user.login.domain.Role;
+import soma.haeya.edupi_user.login.dto.TokenInfo;
+
+@SpringBootTest
+public class TokenProviderTest {
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    private Member member;
+
+    @BeforeEach
+    void init() {
+        member = new Member("asdf@naver.com", "홍길동", Role.ROLE_USER);
+    }
+
+    @Test
+    @DisplayName("회원 정보를 받고 토큰 생성 확인")
+    void generateToken() {
+        String token = tokenProvider.generateToken(member);
+
+        Assertions.assertThat(token).isNotNull();
+    }
+
+    @Test
+    @DisplayName("토큰 정보를 받고 회원 정보 반환")
+    void findUserInfoBy() {
+        String token = tokenProvider.generateToken(member);
+
+        TokenInfo tokenInfo = tokenProvider.findUserInfoBy(token);
+
+        Assertions.assertThat(tokenInfo.getEmail()).isEqualTo(member.getEmail());
+        Assertions.assertThat(tokenInfo.getName()).isEqualTo(member.getName());
+        Assertions.assertThat(tokenInfo.getRole()).isEqualTo(member.getRole());
+    }
+}

--- a/src/test/java/soma/haeya/edupi_user/login/client/MemberApiClientTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/client/MemberApiClientTest.java
@@ -60,7 +60,7 @@ class MemberApiClientTest {
             .email("asdf@naver.com")
             .password("password").build();
 
-        Member result = memberApiClient.findMemberByEmailAndPassword(request);
+        Member result = memberApiClient.retrieveMemberByEmailAndPassword(request);
 
         assertEquals(result.getEmail(), expectedResponse.getEmail());
         assertEquals(result.getName(), expectedResponse.getName());

--- a/src/test/java/soma/haeya/edupi_user/login/client/MemberApiClientTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/client/MemberApiClientTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import soma.haeya.edupi_user.login.client.config.MemberApiRestClientConfig;
 import soma.haeya.edupi_user.login.domain.Member;
-import soma.haeya.edupi_user.login.domain.Role;
 import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
 
 @SpringBootTest
@@ -50,7 +49,7 @@ class MemberApiClientTest {
     @Test
     @DisplayName("이메일과 비밀번호로 회원을 찾는 Http 요청 테스트")
     void testFindMemberByEmailAndPassword() throws JsonProcessingException {
-        Member expectedResponse = new Member(1L, "asdf@naver.com", "", "홍길동", Role.ROLE_USER);
+        Member expectedResponse = new Member(1L, "asdf@naver.com", "", "홍길동", "ROLE_USER");
 
         // mockWebServer 응답 설정
         mockWebServer.enqueue(new MockResponse()

--- a/src/test/java/soma/haeya/edupi_user/login/client/MemberApiClientTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/client/MemberApiClientTest.java
@@ -1,0 +1,69 @@
+package soma.haeya.edupi_user.login.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import soma.haeya.edupi_user.login.client.config.MemberApiRestClientConfig;
+import soma.haeya.edupi_user.login.domain.Member;
+import soma.haeya.edupi_user.login.domain.Role;
+import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
+
+@SpringBootTest
+@Import(MemberApiRestClientConfig.class)
+class MemberApiClientTest {
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private MockWebServer mockWebServer;
+    private MemberApiClient memberApiClient;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start(8081);
+
+        // memberApiClient에 mockWebServer를 적용해 테스트
+        MemberApiRestClientConfig config = new MemberApiRestClientConfig();
+        memberApiClient = config.memberApiClient(
+            mockWebServer.url("/").toString());
+    }
+
+    @AfterEach
+    void shutdown() throws IOException {
+        if (mockWebServer != null) {
+            this.mockWebServer.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("이메일과 비밀번호로 회원을 찾는 Http 요청 테스트")
+    void testFindMemberByEmailAndPassword() throws JsonProcessingException {
+        Member expectedResponse = new Member(1L, "asdf@naver.com", "", "홍길동", Role.ROLE_USER);
+
+        // mockWebServer 응답 설정
+        mockWebServer.enqueue(new MockResponse()
+            .setBody(mapper.writeValueAsString(expectedResponse))
+            .addHeader("Content-Type", "application/json"));
+
+        MemberLoginRequest request = MemberLoginRequest.builder()
+            .email("asdf@naver.com")
+            .password("password").build();
+
+        Member result = memberApiClient.findMemberByEmailAndPassword(request);
+
+        assertEquals(result.getEmail(), expectedResponse.getEmail());
+        assertEquals(result.getName(), expectedResponse.getName());
+    }
+}

--- a/src/test/java/soma/haeya/edupi_user/login/client/MemberApiClientTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/client/MemberApiClientTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import soma.haeya.edupi_user.login.client.config.MemberApiRestClientConfig;
 import soma.haeya.edupi_user.login.domain.Member;
+import soma.haeya.edupi_user.login.domain.Role;
 import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
 
 @SpringBootTest
@@ -49,7 +50,7 @@ class MemberApiClientTest {
     @Test
     @DisplayName("이메일과 비밀번호로 회원을 찾는 Http 요청 테스트")
     void testFindMemberByEmailAndPassword() throws JsonProcessingException {
-        Member expectedResponse = new Member(1L, "asdf@naver.com", "", "홍길동", "ROLE_USER");
+        Member expectedResponse = new Member(1L, "asdf@naver.com", "", "홍길동", Role.ROLE_USER);
 
         // mockWebServer 응답 설정
         mockWebServer.enqueue(new MockResponse()

--- a/src/test/java/soma/haeya/edupi_user/login/controller/MemberControllerTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/controller/MemberControllerTest.java
@@ -36,7 +36,7 @@ class MemberControllerTest {
             .password("asdf1234")
             .build();
 
-        doReturn("token").when(memberService).memberLogin(memberLoginRequest);
+        doReturn("token").when(memberService).login(memberLoginRequest);
 
         mockMvc.perform(post("/member/login")
                 .content(objectMapper.writeValueAsString(memberLoginRequest))

--- a/src/test/java/soma/haeya/edupi_user/login/controller/MemberControllerTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/controller/MemberControllerTest.java
@@ -1,0 +1,50 @@
+package soma.haeya.edupi_user.login.controller;
+
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
+import soma.haeya.edupi_user.login.service.MemberService;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @MockBean
+    MemberService memberService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DisplayName("로그인에 성공하면 jwt 토큰을 쿠키에 넣는다.")
+    void login() throws Exception {
+        MemberLoginRequest memberLoginRequest = MemberLoginRequest.builder()
+            .email("asdf@naver.com")
+            .password("asdf1234")
+            .build();
+
+        doReturn("token").when(memberService).memberLogin(memberLoginRequest);
+
+        mockMvc.perform(post("/member/login")
+                .content(objectMapper.writeValueAsString(memberLoginRequest))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk())
+            .andExpect(cookie().exists("token"));
+
+    }
+
+}

--- a/src/test/java/soma/haeya/edupi_user/login/service/MemberServiceTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/service/MemberServiceTest.java
@@ -1,0 +1,72 @@
+package soma.haeya.edupi_user.login.service;
+
+import static org.mockito.Mockito.when;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import soma.haeya.edupi_user.login.auth.TokenProvider;
+import soma.haeya.edupi_user.login.client.MemberApiClient;
+import soma.haeya.edupi_user.login.domain.Member;
+import soma.haeya.edupi_user.login.domain.Role;
+import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberApiClient memberRepository;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    private MemberLoginRequest memberLoginRequest;
+
+    @BeforeEach
+    void init() {
+        memberLoginRequest = MemberLoginRequest.builder()
+            .email("asdf@naver.com")
+            .password("asdf1234")
+            .build();
+    }
+
+
+    @Test
+    @DisplayName("아이디와 패스워드에 맞는 멤버가 있으면 token을 반환한다.")
+    void memberLogin() {
+
+        Member expectedMember = new Member("asdf@naver.com", "홍길동", Role.ROLE_USER);
+
+        String expectedToken = "token";
+
+        when(memberRepository.findMemberByEmailAndPassword(memberLoginRequest)).thenReturn(
+            expectedMember);
+        when(tokenProvider.generateToken(expectedMember)).thenReturn(expectedToken);
+
+        String resultToken = memberService.memberLogin(memberLoginRequest);
+
+        Assertions.assertThat(resultToken).isEqualTo(expectedToken);
+    }
+
+    @Test
+    @DisplayName("아이디 패스워드에 맞는 멤버가 없으면 예외를 반환한다.")
+    void memberLoginException() {
+
+        when(memberRepository.findMemberByEmailAndPassword(memberLoginRequest)).thenThrow(
+            new IllegalArgumentException("아이디 비밀번호가 일치하지 않습니다.")
+        );
+
+        Assertions.assertThatThrownBy(() -> memberService.memberLogin(memberLoginRequest))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("아이디 비밀번호가 일치하지 않습니다.");
+    }
+
+}

--- a/src/test/java/soma/haeya/edupi_user/login/service/MemberServiceTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/service/MemberServiceTest.java
@@ -50,7 +50,7 @@ public class MemberServiceTest {
             expectedMember);
         when(tokenProvider.generateToken(expectedMember)).thenReturn(expectedToken);
 
-        String resultToken = memberService.memberLogin(memberLoginRequest);
+        String resultToken = memberService.login(memberLoginRequest);
 
         Assertions.assertThat(resultToken).isEqualTo(expectedToken);
     }
@@ -63,7 +63,7 @@ public class MemberServiceTest {
             new IllegalArgumentException("아이디 비밀번호가 일치하지 않습니다.")
         );
 
-        Assertions.assertThatThrownBy(() -> memberService.memberLogin(memberLoginRequest))
+        Assertions.assertThatThrownBy(() -> memberService.login(memberLoginRequest))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("아이디 비밀번호가 일치하지 않습니다.");
     }

--- a/src/test/java/soma/haeya/edupi_user/login/service/MemberServiceTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/service/MemberServiceTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import soma.haeya.edupi_user.login.auth.TokenProvider;
 import soma.haeya.edupi_user.login.client.MemberApiClient;
 import soma.haeya.edupi_user.login.domain.Member;
-import soma.haeya.edupi_user.login.domain.Role;
 import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,7 +42,7 @@ public class MemberServiceTest {
     @DisplayName("아이디와 패스워드에 맞는 멤버가 있으면 token을 반환한다.")
     void memberLogin() {
 
-        Member expectedMember = new Member("asdf@naver.com", "홍길동", Role.ROLE_USER);
+        Member expectedMember = new Member(1L, "asdf@naver.com", "asdf1234", "홍길동", "ROLE_USER");
 
         String expectedToken = "token";
 

--- a/src/test/java/soma/haeya/edupi_user/login/service/MemberServiceTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/service/MemberServiceTest.java
@@ -46,7 +46,7 @@ public class MemberServiceTest {
 
         String expectedToken = "token";
 
-        when(memberRepository.findMemberByEmailAndPassword(memberLoginRequest)).thenReturn(
+        when(memberRepository.retrieveMemberByEmailAndPassword(memberLoginRequest)).thenReturn(
             expectedMember);
         when(tokenProvider.generateToken(expectedMember)).thenReturn(expectedToken);
 
@@ -59,7 +59,7 @@ public class MemberServiceTest {
     @DisplayName("아이디 패스워드에 맞는 멤버가 없으면 예외를 반환한다.")
     void memberLoginException() {
 
-        when(memberRepository.findMemberByEmailAndPassword(memberLoginRequest)).thenThrow(
+        when(memberRepository.retrieveMemberByEmailAndPassword(memberLoginRequest)).thenThrow(
             new IllegalArgumentException("아이디 비밀번호가 일치하지 않습니다.")
         );
 

--- a/src/test/java/soma/haeya/edupi_user/login/service/MemberServiceTest.java
+++ b/src/test/java/soma/haeya/edupi_user/login/service/MemberServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import soma.haeya.edupi_user.login.auth.TokenProvider;
 import soma.haeya.edupi_user.login.client.MemberApiClient;
 import soma.haeya.edupi_user.login.domain.Member;
+import soma.haeya.edupi_user.login.domain.Role;
 import soma.haeya.edupi_user.login.dto.MemberLoginRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,7 +43,7 @@ public class MemberServiceTest {
     @DisplayName("아이디와 패스워드에 맞는 멤버가 있으면 token을 반환한다.")
     void memberLogin() {
 
-        Member expectedMember = new Member(1L, "asdf@naver.com", "asdf1234", "홍길동", "ROLE_USER");
+        Member expectedMember = new Member("asdf@naver.com", "홍길동", Role.ROLE_USER);
 
         String expectedToken = "token";
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #7 

## 📝 작업 내용

- localhost:8080/api/v1/member/login:  localhost:8081/api/v1/member/login으로 아이디와, 비밀번호를 보내 유효한 아이디, 비밀번호인지 회원정보를 찾아온다. 회원정보가 있으면 token을 생성해서 반환
- localhost:8080/api/v1/member/login: token을 받아 유효한 token이라면, token에 담긴 정보를 반환한다.

### 스크린샷 (선택)
<img width="854" alt="스크린샷 2024-07-29 오후 3 36 39" src="https://github.com/user-attachments/assets/4dd5cf46-8641-429d-b91f-245a42fd2248">
<img width="881" alt="스크린샷 2024-07-29 오후 3 36 57" src="https://github.com/user-attachments/assets/f3e53406-569c-42a8-bddd-bb9b1ac87ebd">


## 💬 리뷰 요구사항(선택)

- 이해안가는 부분이 있거나 이상한 부분이 있다면 알려주세요!
