### PR TITLE
[#49]fix: cookie에 SameSite 속성과 Secure 속성 추가

### DIFF
--- a/src/main/java/soma/edupiuser/account/AccountController.java
+++ b/src/main/java/soma/edupiuser/account/AccountController.java
@@ -39,6 +39,8 @@ public class AccountController implements AccountOpenApi {
         Cookie cookie = new Cookie("token", token);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
+        cookie.setAttribute("SameSite", "None");
+        cookie.setSecure(true);
 
         response.addCookie(cookie);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #49 

## 📝 작업 내용
```
### SameSite=None
None은 현재까지 사용되던 Default 정책으로 SameSite를 검증하지 않는다. 그래서 A 사이트에서 B 사이트로 요청을 전송하게 되면 B 사이트의 쿠키가 붙어서 전송된다(보안상 좋지 않음).

### SameSite=Strict
Strict는 쿠키의 SameSite 검사를 강하게 제한하는 정책으로 소스가 되는 도메인과 대상 도메인이 일치해야만 쿠키가 포함되어 전송된다. 예를 들면
(O) http://www.google.com/=> http://www.google.com/
(X) http://www.hahwul.com/ => http://www.google.com/ 

### SameSite=Lax
마지막으로 Lax는 기존 Strict 정책에서 예외 처리가 몇 개 된 정책이다. 일반적으로 GET을 사용하는 요청 중 앵커태그(<a href>) , form의 get 메소드(<form method=get>) 정도만 예외되고 나머지는 Strict와 동일하게 SameSite가 아닌 경우 쿠키 전송이 차단된다.

허나 20년 2월 4일 릴리즈된 구글 크롬(Google Chrome)80버전부터 새로운 쿠키 정책이 적용 되어 Cookie의  SameSite 속성의 기본값이 "None"에서 "Lax"로 변경되었다.

서로 다른 도메인을 사용하고 있는 리액트(5000번 포트)와 스프링(8080번 포트) 사이에서 쿠키값을 주고 받을 수 없다라는 뜻이다.
```
지금은 SameSite가 Lax로 설정되어 있어 포트번호만 달라도 cookie를 set할 수 없기 떄문에 None으로 설정해줘야 한다.


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

