### PR TITLE
[#64]fix: request matcher 수정 및 예외 정의

### DIFF
--- a/src/main/java/soma/edupiuser/oauth/config/SecurityConfig.java
+++ b/src/main/java/soma/edupiuser/oauth/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package soma.edupiuser.oauth.config;
 
-import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,17 +38,12 @@ public class SecurityConfig {
                 HeadersConfigurer.FrameOptionsConfig::disable)) // For H2 DB
             .formLogin(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
-            .authorizeHttpRequests((requests) -> requests
-                .requestMatchers(antMatcher("/v1/account/**")).permitAll()
-                .requestMatchers(antMatcher("/health-check")).permitAll()
-                .anyRequest().authenticated()
-            )
             .sessionManagement(sessions -> sessions.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .oauth2Login(configure ->
                 configure
-                    .authorizationEndpoint(config -> {
-                        config.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository);
-                    })
+                    .authorizationEndpoint(config ->
+                        config.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository)
+                    )
                     .userInfoEndpoint(config -> config.userService(customOAuth2UserService))
                     .successHandler(oAuth2AuthenticationSuccessHandler) // 인증 성공 시 처리
                     .failureHandler(oAuth2AuthenticationFailureHandler) //  인증 실패 시 처리

--- a/src/main/java/soma/edupiuser/web/GlobalExceptionHandler.java
+++ b/src/main/java/soma/edupiuser/web/GlobalExceptionHandler.java
@@ -45,7 +45,7 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .body(new ErrorResponse(ErrorEnum.TASK_FAIL.getCode(), "쿠키에 필요한 값이 없습니다."));
+            .body(new ErrorResponse(ErrorEnum.TOKEN_NOT_FOUND.getCode(), ErrorEnum.TOKEN_NOT_FOUND.getDetail()));
     }
 
 }

--- a/src/main/java/soma/edupiuser/web/GlobalExceptionHandler.java
+++ b/src/main/java/soma/edupiuser/web/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package soma.edupiuser.web;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import soma.edupiuser.account.exception.DuplicatedEmailException;
@@ -36,7 +37,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(new ErrorResponse(ErrorEnum.TASK_FAIL.getCode(), ErrorEnum.TASK_FAIL.getDetail()));
+    }
 
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ErrorResponse> handleMissingCookieExceptions(MissingRequestCookieException exception) {
+        log.error("[Meta Exception] code={}, message={}", exception.getStatusCode(), exception.getMessage());
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(ErrorEnum.TASK_FAIL.getCode(), "쿠키에 필요한 값이 없습니다."));
     }
 
 }

--- a/src/main/java/soma/edupiuser/web/GlobalExceptionHandler.java
+++ b/src/main/java/soma/edupiuser/web/GlobalExceptionHandler.java
@@ -41,7 +41,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MissingRequestCookieException.class)
     public ResponseEntity<ErrorResponse> handleMissingCookieExceptions(MissingRequestCookieException exception) {
-        log.error("[Meta Exception] code={}, message={}", exception.getStatusCode(), exception.getMessage());
+        log.error("[MissingRequestCookieException] code={}, message={}", exception.getStatusCode(),
+            exception.getMessage());
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/soma/edupiuser/web/auth/TokenProvider.java
+++ b/src/main/java/soma/edupiuser/web/auth/TokenProvider.java
@@ -64,7 +64,7 @@ public class TokenProvider {
 
     private Claims getClaims(String token) {
         if (token == null || token.isEmpty()) {
-            throw new IllegalArgumentException("토큰이 없습니다.");
+            throw new AccountException(ErrorEnum.TOKEN_NOT_FOUND);
         }
 
         try {

--- a/src/main/java/soma/edupiuser/web/exception/ErrorEnum.java
+++ b/src/main/java/soma/edupiuser/web/exception/ErrorEnum.java
@@ -1,7 +1,9 @@
 package soma.edupiuser.web.exception;
 
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@Getter
 public enum ErrorEnum {
     // 400
     TOKEN_EXPIRE(HttpStatus.BAD_REQUEST, "AC-400001", "The token has expired"),
@@ -13,6 +15,7 @@ public enum ErrorEnum {
         "Unable to get resources due to network issues. check the server is started"),
     RESPONSE_FORMAT_ERROR(HttpStatus.BAD_REQUEST, "AC-400006",
         "Invalid error response format."),
+    TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "AC-400007", "Token not found."),
 
     META_SERVER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "AC-500001", "Meta server Exception"),
 
@@ -26,18 +29,6 @@ public enum ErrorEnum {
         this.httpStatus = httpStatus;
         this.code = code;
         this.detail = details;
-    }
-
-    public HttpStatus getHttpStatus() {
-        return httpStatus;
-    }
-
-    public String getCode() {
-        return code;
-    }
-
-    public String getDetail() {
-        return detail;
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #64 

## 📝 작업 내용

- request Matcher 제거
- cookie에 token이 없을 때 예외 처리 추가
- TokenProvider 예외 처리

### 스크린샷 (선택)

